### PR TITLE
Chore: Fix 'Add an Arena' feature fails to redirect to login page if the user isn't logged in (Issue #42)

### DIFF
--- a/client/pages/add-gym-listing.tsx
+++ b/client/pages/add-gym-listing.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { useSelector } from 'react-redux';
 import { RootState } from "../redux/rootState";
 import AddGymForm from "../components/add-gym-form";
@@ -9,11 +9,11 @@ export default function AddGymListing(props: {}) {
   const [isLoading, setIsLoading] = useState(false);
   const isLoggedIn = useSelector((state: RootState) => state.app.isLoggedIn);
 
-  // useEffect(() => {
-  //   if (!isLoggedIn) {
-  //     window.location.hash = '#auth';
-  //   }
-  // }, [isLoggedIn]);
+  useEffect(() => {
+    if (!isLoggedIn) {
+      window.location.hash = '#auth';
+    }
+  }, [isLoggedIn]);
 
   return (
     <>


### PR DESCRIPTION
### Description
An useEffect hook that is used to determine if the current user is authorized to use the 'Add an Arena' form was commented out during previous development. I re-added the useEffect hook and verified that the user is now redirected to the auth page properly. I am looking to merge this into the master branch as this is a breaking bug in the live deployment.

Fixes #42

### Types of changes
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ]  New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update