### PR TITLE
Fix: Fix home page H1 alignment

### DIFF
--- a/server/public/pages/home-page.css
+++ b/server/public/pages/home-page.css
@@ -12,7 +12,8 @@
   }
 }
 .home__hero {
-  height: 30%;
+  width: 100%;
+  height: 200px;
   background-image: url(./images/colosseum_color.jpg);
   background-size: cover;
   background-position: center center;
@@ -28,7 +29,7 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-  height: 70%;
+  min-height: fit-content;
   width: 100%;
   padding: 2rem;
   background-color: #FEFDFB;

--- a/server/public/scss/pages/home-page.scss
+++ b/server/public/scss/pages/home-page.scss
@@ -22,7 +22,8 @@
   }
 
   &__hero {
-    height: 30%;
+    width: 100%;
+    height: 200px;
 
     background-image: url(./images/colosseum_color.jpg);
     background-size: cover;
@@ -40,7 +41,7 @@
     flex-direction: column;
     justify-content: center;
 
-    height: 70%;
+    min-height: fit-content;
     width: 100%;
     padding: 2rem;
 

--- a/server/public/styles.css
+++ b/server/public/styles.css
@@ -209,7 +209,8 @@ footer {
   }
 }
 .home__hero {
-  height: 30%;
+  width: 100%;
+  height: 200px;
   background-image: url(./images/colosseum_color.jpg);
   background-size: cover;
   background-position: center center;
@@ -225,7 +226,7 @@ footer {
   display: flex;
   flex-direction: column;
   justify-content: center;
-  height: 70%;
+  min-height: fit-content;
   width: 100%;
   padding: 2rem;
   background-color: #FEFDFB;


### PR DESCRIPTION
Give hero image on home page definite height to prevent hero h1 from overfilling on screens with smaller widths

<!--- Thank you for submitting a pull request! Please use the following template to draft your PR. -->

## Description
<!--- Describe your changes -->
- Heights of the hero image and hero sections were based on percentage values leading to overflowing items on smaller screens. This doesn't show up in the emulator but does show up on actual phone screens.
<!--- Include a reference to the issue this fixes with #XXX e.g. #123 -->
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
